### PR TITLE
Fixed Attrs ValueError (No mandatory attributes allowed after an attr…

### DIFF
--- a/gsb/intercept.py
+++ b/gsb/intercept.py
@@ -327,6 +327,8 @@ class Reader(Intercept, _ReaderBase):
     before_line = attrib(default=Factory(lambda: None))
     after_line = attrib(default=Factory(lambda: None))
     buffer = attrib(default=Factory(str))
+    done=attrib(default=Factory(lambda: None))
+    
 
     def explain(self, connection):
         """Explain this reader."""
@@ -429,6 +431,8 @@ class YesOrNo(Intercept, _YesOrNoBase):
 
     no = attrib(default=Factory(lambda: None))
     prompt = attrib(default=Factory(lambda: None))
+    yes=attrib(default=Factory(lambda: None))
+    question=attrib(default=Factory(str))
 
     def __attrs_post_init__(self):
         if self.prompt is None:


### PR DESCRIPTION
…ibute with a default value or factory) for attributes Attribute(name='done', default=NOTHING, validator=None, repr=True, cmp=True, hash=None, init=True, metadata=mappingproxy({}), type=None, converter=None) and Attribute(name='question', default=NOTHING, validator=None, repr=True, cmp=True, hash=None, init=True, metadata=mappingproxy({}), type=None, converter=None) for the Reader and YesOrNo classes to allow users to import GSB again.